### PR TITLE
Improve bundle size by 2x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,37 +1,45 @@
-const keccak256 = require('keccak256')
+const keccak = require('keccak')
 
-function toChecksumAddress (address, chainId = null) {
+function toChecksumAddress(address, chainId = null) {
   if (typeof address !== 'string') {
     return ''
   }
 
   if (!/^(0x)?[0-9a-f]{40}$/i.test(address)) {
-    throw new Error(`Given address "${address}" is not a valid Ethereum address.`)
+    throw new Error(
+      `Given address "${address}" is not a valid Ethereum address.`
+    )
   }
 
   const stripAddress = stripHexPrefix(address).toLowerCase()
   const prefix = chainId != null ? chainId.toString() + '0x' : ''
-  const keccakHash = keccak256(prefix + stripAddress)
-    .toString('hex')
-    .replace(/^0x/i, '')
+  const keccakHash = keccak('keccak256')
+    .update(prefix + stripAddress)
+    .digest('hex')
   let checksumAddress = '0x'
 
   for (let i = 0; i < stripAddress.length; i++) {
-    checksumAddress += parseInt(keccakHash[i], 16) >= 8 ? stripAddress[i].toUpperCase() : stripAddress[i]
+    checksumAddress +=
+      parseInt(keccakHash[i], 16) >= 8
+        ? stripAddress[i].toUpperCase()
+        : stripAddress[i]
   }
 
   return checksumAddress
 }
 
-function checkAddressChecksum (address, chainId = null) {
+function checkAddressChecksum(address, chainId = null) {
   const stripAddress = stripHexPrefix(address).toLowerCase()
   const prefix = chainId != null ? chainId.toString() + '0x' : ''
-  const keccakHash = keccak256(prefix + stripAddress)
-    .toString('hex')
-    .replace(/^0x/i, '')
+  const keccakHash = keccak('keccak256')
+    .update(prefix + stripAddress)
+    .digest('hex')
 
   for (let i = 0; i < stripAddress.length; i++) {
-    let output = parseInt(keccakHash[i], 16) >= 8 ? stripAddress[i].toUpperCase() : stripAddress[i]
+    let output =
+      parseInt(keccakHash[i], 16) >= 8
+        ? stripAddress[i].toUpperCase()
+        : stripAddress[i]
     if (stripHexPrefix(address)[i] !== output) {
       return false
     }
@@ -39,7 +47,7 @@ function checkAddressChecksum (address, chainId = null) {
   return true
 }
 
-function stripHexPrefix (value) {
+function stripHexPrefix(value) {
   return value.slice(0, 2) === '0x' ? value.slice(2) : value
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/miguelmota/ethereum-checksum-address/blob/master/LICENSE"
   },
   "dependencies": {
-    "keccak256": "^1.0.0",
+    "keccak": "^3.0.2",
     "meow": "^5.0.0"
   },
   "keywords": [


### PR DESCRIPTION
When comparing the size before this PR and after, it went:

**Before**

```
size: 87831,
gzip: 24612,
```

**After**

```
size: 42981,
gzip: 13020,
```

You can see from the original EIP that the `keccak` library is trusted by the Eth core devs and is a secure package: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md

Here are the bundle size comparisons:

https://bundlephobia.com/package/keccak256@1.0.3
https://bundlephobia.com/package/keccak@3.0.2

## Test the size diff yourself

```ts
// belongs in the parent directory to "ethereum-checksum-address"
import { getPackageStats } from "package-build-stats";
import path from "path";

(async () => {
  const results = await getPackageStats(
    path.join(__dirname, "ethereum-checksum-address"),
    {}
  );
  console.log({ results });
})();
```
## My VSCode bundle diff

![image](https://user-images.githubusercontent.com/3408480/133148239-76334f3e-c3c1-44dd-b2f2-e2308c8d52d3.png)

(this is made possible with https://github.com/wix/import-cost)