### PR TITLE
SNYK-JS-TRIMNEWLINES-1298042

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "keccak": "^3.0.2",
-    "meow": "^5.0.0"
+    "meow": "^10.1.2"
   },
   "keywords": [
     "ethereum",
@@ -48,7 +48,7 @@
   ],
   "devDependencies": {
     "browserify": "^16.5.1",
-    "standard": "^12.0.1",
+    "standard": "^16.0.4",
     "tape": "^4.10.2"
   }
 }


### PR DESCRIPTION
Fixed dependencies as per the following:

- https://security.snyk.io/vuln/SNYK-JS-TRIMNEWLINES-1298042
- https://github.com/advisories/GHSA-93q8-gq69-wqmw